### PR TITLE
Added keepWords option and fixed unresponsive config function

### DIFF
--- a/src/prefix.js
+++ b/src/prefix.js
@@ -203,13 +203,11 @@ class WebAdapter {
             }
         }, options));
     }
-    config(name, value) {
-        if (typeof name === 'string') {
-            this._config[name] = value;
-        } else {
-            const { completion, ...rest } = name;
-            this._term.settings().completion = completion;
-            $.extend(rest, name);
+    config(name) {
+        if (typeof name === 'object') {
+            for (const [key, value] of Object.entries(name)) {
+                this._config[key] = value
+            }
         }
     }
     store(name, ...args) {

--- a/src/prefix.js
+++ b/src/prefix.js
@@ -165,6 +165,7 @@ function to_string(object) {
 class WebAdapter {
     constructor(config = {}) {
         this._config = $.extend({
+            keepWords: false,
             newline: true,
             loop_threshold: 500,
             loop_timeout: 200
@@ -254,10 +255,10 @@ class WebAdapter {
         if (typeof arg !== 'function') {
             arg = to_string(arg);
         }
-        this._term.echo(arg, { newline: this._config.newline });
+        this._term.echo(arg, { keepWords: this._config.keepWords, newline: this._config.newline });
     }
     echo_extra(string, delay) {
-        return this._term.echo(string, { typing: true, delay });
+        return this._term.echo(string, { keepWords: this._config.keepWords, typing: true, delay });
     }
     enter(string) {
         return this._term.enter(string);


### PR DESCRIPTION
`config` as described in the [documentation](https://github.com/jcubic/gaiman/wiki/Reference-Manual) was not successfully setting the configurable options. I'm not sure if this is the intended behavior, but I fixed it for my use.

Additionally `keepWords` is now passed along by both `echo` functions, but it is set to `false` as the default. This should address #77.